### PR TITLE
Use PropTypes from the separate npm library prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "webpack-node-externals": "^1.0.0"
   },
   "dependencies": {
-    "classnames": "^2.2.3"
+    "classnames": "^2.2.3",
+    "prop-types": "^15.6.0"
   },
   "repository": {
     "type": "git",

--- a/src/MaterialIcon.js
+++ b/src/MaterialIcon.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
 const validSizes = [2, 3, 4, 5]

--- a/src/MaterialIconStack.js
+++ b/src/MaterialIconStack.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
 const MaterialIconStack = ({ children, large }) => {


### PR DESCRIPTION
Since PropTypes has been removed in React v15.5 (https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactproptypes), I've included it from the porp-types npm package

(Sorry for other, closed, PR. Did something wrong and couldn't manage to connect PR to other branch)